### PR TITLE
Add #keys methods for ViewResponse and StreamingViewResponse

### DIFF
--- a/lib/analysand/streaming_view_response.rb
+++ b/lib/analysand/streaming_view_response.rb
@@ -55,6 +55,22 @@ module Analysand
       each { |r| yield r['doc'] if r.has_key?('doc') }
     end
 
+    # Public: Yields document keys from the view stream.
+    #
+    # Note that ##keys and #rows advance the same stream, so expect to miss half
+    # your rows if you do something like
+    #
+    #     resp.keys.zip(resp.rows)
+    #
+    # If this is a problem for you, let me know and we can work out a solution.
+    def keys
+      to_enum(:get_keys)
+    end
+
+    def get_keys
+      each { |r| yield r['key'] if r.has_key?('key') }
+    end
+
     def total_rows
       read until @generator.total_rows
 

--- a/lib/analysand/view_response.rb
+++ b/lib/analysand/view_response.rb
@@ -20,5 +20,9 @@ module Analysand
     def docs
       rows.map { |r| r['doc'] }.compact
     end
+
+    def keys
+      rows.map { |r| r['key'] }.compact
+    end
   end
 end

--- a/spec/analysand/view_response_spec.rb
+++ b/spec/analysand/view_response_spec.rb
@@ -40,5 +40,23 @@ module Analysand
         end
       end
     end
+
+    describe '#keys' do
+      describe 'if the view includes docs' do
+        subject { ViewResponse.new(double(:body => resp_with_docs)) }
+
+        it 'returns the value of the "key" key in each row' do
+          subject.keys.should == ['foo']
+        end
+      end
+
+      describe 'if the view does not include docs' do
+        subject { ViewResponse.new(double(:body => resp_without_docs)) }
+
+        it 'returns []' do
+          subject.keys.should == ['foo']
+        end
+      end
+    end
   end
 end

--- a/spec/analysand/view_streaming_spec.rb
+++ b/spec/analysand/view_streaming_spec.rb
@@ -64,6 +64,11 @@ module Analysand
         expect(resp.docs.take(10).all? { |d| d.has_key?('_id') }).to eq(true)
       end
 
+      it 'yields keys' do
+        resp = get_view(:include_docs => false, :stream => true)
+        expect(resp.keys.take(10).each { |k| k }).to eq(['abc123'] * 10)
+      end
+
       it 'returns rows as soon as possible' do
         # first, make sure the view's built
         db.head('_design/doc/_view/a_view', admin_credentials)


### PR DESCRIPTION
This method is similar to the #docs methods, but is used to return only keys.
